### PR TITLE
feat: added more accessible settings menu 

### DIFF
--- a/Tureng/popup.html
+++ b/Tureng/popup.html
@@ -15,9 +15,49 @@
     <div id="form_div" class="btn-group btn-group-justified">
       <input type="search" class="form-control" id="search-input" placeholder="Türkçe veya İngilizce" autocomplete="off" autofocus tabindex="1">
       <button type="button" class="btn btn-primary" id="tureng">Tureng</button>
-     <!-- <button type="button" class="btn btn-secondary" id="settings"><i class="fa fa-sliders" aria-hidden="true"></i>  -->
+      <button type="button" id="settings-toggle" title="Ayarlar">
+        <i class="fa fa-cog fa-spin-on-hover" aria-hidden="true"></i>
+        <span>Ayarlar</span>
       </button>
     </div>
+    </div>
+
+    <!-- Inline Settings Panel -->
+    <div id="settings-panel">
+      <div class="settings-header">
+        <span><i class="fa fa-sliders" aria-hidden="true"></i> Ayarlar</span>
+        <button type="button" id="settings-close" title="Kapat">&times;</button>
+      </div>
+      <div class="settings-body">
+        <div class="settings-row">
+          <label for="popup-modifier-select">Popup Tetikleme Tusu:</label>
+          <select id="popup-modifier-select">
+            <option value="alt">Alt + Cift Tiklama</option>
+            <option value="ctrl">Ctrl + Cift Tiklama</option>
+            <option value="shift">Shift + Cift Tiklama</option>
+            <option value="meta">Meta (Cmd/Win) + Cift Tiklama</option>
+            <option value="none">Sadece Cift Tiklama</option>
+          </select>
+        </div>
+        <div class="settings-row">
+          <label for="popup-max-results">Maks Sonuc Sayisi:</label>
+          <select id="popup-max-results">
+            <option value="3">3</option>
+            <option value="5">5</option>
+            <option value="10">10</option>
+            <option value="15">15</option>
+          </select>
+        </div>
+        <div class="settings-row">
+          <label for="popup-tts-rate">TTS Konusma Hizi:</label>
+          <input type="range" id="popup-tts-rate" min="0.5" max="2.0" step="0.1" value="0.8">
+          <span id="tts-rate-value">0.8</span>
+        </div>
+        <p id="popup-settings-status">Kaydedildi!</p>
+      </div>
+      <div class="settings-footer">
+        <a href="info.html" target="_blank" id="all-settings-link">Tum Ayarlar ve Bilgi <i class="fa fa-external-link" aria-hidden="true"></i></a>
+      </div>
     </div>
 
     <div id="voice-tts" class="container">

--- a/Tureng/scripts/content.js
+++ b/Tureng/scripts/content.js
@@ -3,7 +3,7 @@
 
   const POPUP_ID = 'tureng-selection-popup';
   const STYLE_ID = 'tureng-selection-style';
-  const MAX_RESULTS = 5;
+  let MAX_RESULTS = 5;
 
   function ensureStyles() {
     if (document.getElementById(STYLE_ID)) {
@@ -166,7 +166,8 @@
   }
 
   const defaultSettings = {
-    modifier: 'alt'
+    modifier: 'alt',
+    maxResults: 5
   };
 
   let settings = { ...defaultSettings };
@@ -174,6 +175,7 @@
   function loadSettings() {
     chrome.storage.sync.get(defaultSettings, (stored) => {
       settings = { ...defaultSettings, ...stored };
+      MAX_RESULTS = settings.maxResults || 5;
     });
   }
 
@@ -233,6 +235,10 @@
     }
     if (changes.modifier) {
       settings.modifier = changes.modifier.newValue;
+    }
+    if (changes.maxResults) {
+      settings.maxResults = changes.maxResults.newValue;
+      MAX_RESULTS = settings.maxResults || 5;
     }
   });
 

--- a/Tureng/scripts/options.js
+++ b/Tureng/scripts/options.js
@@ -2,7 +2,9 @@
   'use strict';
 
   const defaultSettings = {
-    modifier: 'alt'
+    modifier: 'alt',
+    maxResults: 5,
+    ttsRate: 0.8
   };
 
   const modifierSelect = document.getElementById('modifier-select');

--- a/Tureng/scripts/popup.js
+++ b/Tureng/scripts/popup.js
@@ -168,21 +168,91 @@ window.onload = async () => {
 
 };
 
-// TTS
+// ---- Inline Settings Panel ----
+const settingsDefaults = { modifier: 'alt', maxResults: 5, ttsRate: 0.8 };
+let currentSettings = { ...settingsDefaults };
+
+function loadPopupSettings() {
+  chrome.storage.sync.get(settingsDefaults, (stored) => {
+    currentSettings = { ...settingsDefaults, ...stored };
+    applyPopupSettings();
+  });
+}
+
+function applyPopupSettings() {
+  const modSelect = document.getElementById('popup-modifier-select');
+  const maxSelect = document.getElementById('popup-max-results');
+  const rateSlider = document.getElementById('popup-tts-rate');
+  const rateLabel = document.getElementById('tts-rate-value');
+
+  if (modSelect) modSelect.value = currentSettings.modifier;
+  if (maxSelect) maxSelect.value = String(currentSettings.maxResults);
+  if (rateSlider) rateSlider.value = currentSettings.ttsRate;
+  if (rateLabel) rateLabel.textContent = currentSettings.ttsRate;
+}
+
+function savePopupSettings() {
+  const modSelect = document.getElementById('popup-modifier-select');
+  const maxSelect = document.getElementById('popup-max-results');
+  const rateSlider = document.getElementById('popup-tts-rate');
+
+  currentSettings.modifier = modSelect ? modSelect.value : settingsDefaults.modifier;
+  currentSettings.maxResults = maxSelect ? parseInt(maxSelect.value, 10) : settingsDefaults.maxResults;
+  currentSettings.ttsRate = rateSlider ? parseFloat(rateSlider.value) : settingsDefaults.ttsRate;
+
+  chrome.storage.sync.set(currentSettings, () => {
+    const status = document.getElementById('popup-settings-status');
+    if (status) {
+      status.style.display = 'block';
+      clearTimeout(savePopupSettings._timer);
+      savePopupSettings._timer = setTimeout(() => {
+        status.style.display = 'none';
+      }, 1200);
+    }
+  });
+}
+
+// Toggle panel open/close
+document.getElementById('settings-toggle').addEventListener('click', () => {
+  const panel = document.getElementById('settings-panel');
+  const btn = document.getElementById('settings-toggle');
+  panel.classList.toggle('open');
+  btn.classList.toggle('panel-open');
+});
+document.getElementById('settings-close').addEventListener('click', () => {
+  document.getElementById('settings-panel').classList.remove('open');
+  document.getElementById('settings-toggle').classList.remove('panel-open');
+});
+
+// Wire setting controls
+document.getElementById('popup-modifier-select').addEventListener('change', savePopupSettings);
+document.getElementById('popup-max-results').addEventListener('change', savePopupSettings);
+document.getElementById('popup-tts-rate').addEventListener('input', () => {
+  document.getElementById('tts-rate-value').textContent = document.getElementById('popup-tts-rate').value;
+});
+document.getElementById('popup-tts-rate').addEventListener('change', savePopupSettings);
+
+loadPopupSettings();
+
+// TTS (uses stored rate)
+function getTtsRate() {
+  return currentSettings.ttsRate || 0.8;
+}
+
 document.getElementById('flag-tr').addEventListener('click', ()=>{
-  chrome.tts.speak(document.getElementById('search-input').value, {'lang': 'tr-TR', 'rate': 0.8});
+  chrome.tts.speak(document.getElementById('search-input').value, {'lang': 'tr-TR', 'rate': getTtsRate()});
 });
 
 document.getElementById('flag-us').addEventListener('click', ()=>{
-  chrome.tts.speak(document.getElementById('search-input').value, {'lang': 'en-US', 'rate': 0.8});
+  chrome.tts.speak(document.getElementById('search-input').value, {'lang': 'en-US', 'rate': getTtsRate()});
 });
 
 document.getElementById('flag-uk').addEventListener('click', ()=>{
-  chrome.tts.speak(document.getElementById('search-input').value, {'lang': 'en-GB', 'rate': 0.8});
+  chrome.tts.speak(document.getElementById('search-input').value, {'lang': 'en-GB', 'rate': getTtsRate()});
 });
 
 document.getElementById('flag-au').addEventListener('click', ()=>{
-  chrome.tts.speak(document.getElementById('search-input').value, {'lang': 'en-AU', 'rate': 0.8});
+  chrome.tts.speak(document.getElementById('search-input').value, {'lang': 'en-AU', 'rate': getTtsRate()});
 });
 
 // tureng-logo

--- a/Tureng/styles/main.css
+++ b/Tureng/styles/main.css
@@ -86,3 +86,162 @@ table tbody a:hover {
 .search_results {
   width: 450px;
 }
+
+/* ---- Settings Toggle Button ---- */
+#settings-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  background: linear-gradient(135deg, #BD1E2C, #e0313f);
+  border: none;
+  color: #fff;
+  font-size: 13px;
+  font-weight: 600;
+  padding: 7px 14px;
+  margin-left: 6px;
+  border-radius: 6px;
+  cursor: pointer;
+  transition: background 0.25s, box-shadow 0.25s, transform 0.15s;
+  outline: none;
+  box-shadow: 0 2px 6px rgba(189, 30, 44, 0.35);
+  animation: settingsPulse 2s ease-in-out 0.5s 3;
+}
+#settings-toggle i {
+  font-size: 15px;
+  transition: transform 0.4s ease;
+}
+#settings-toggle:hover {
+  background: linear-gradient(135deg, #a01825, #c9252f);
+  box-shadow: 0 3px 10px rgba(189, 30, 44, 0.5);
+  transform: translateY(-1px);
+}
+#settings-toggle:hover i {
+  transform: rotate(90deg);
+}
+#settings-toggle:active {
+  transform: translateY(0);
+  box-shadow: 0 1px 4px rgba(189, 30, 44, 0.3);
+}
+#settings-toggle.panel-open {
+  background: linear-gradient(135deg, #8a1420, #a01825);
+}
+
+@keyframes settingsPulse {
+  0%, 100% { box-shadow: 0 2px 6px rgba(189, 30, 44, 0.35); }
+  50% { box-shadow: 0 2px 14px rgba(189, 30, 44, 0.6); }
+}
+
+/* ---- Settings Panel ---- */
+#settings-panel {
+  display: none;
+  background: #fafafa;
+  border: 1px solid #e0e0e0;
+  border-radius: 6px;
+  margin: 0 6px 8px 6px;
+  font-size: 13px;
+  overflow: hidden;
+  animation: settingsSlideDown 0.2s ease-out;
+}
+
+@keyframes settingsSlideDown {
+  from {
+    opacity: 0;
+    max-height: 0;
+  }
+  to {
+    opacity: 1;
+    max-height: 400px;
+  }
+}
+
+#settings-panel.open {
+  display: block;
+}
+
+.settings-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 8px 12px;
+  background: #BD1E2C;
+  color: #fff;
+  font-weight: 600;
+  font-size: 13px;
+}
+.settings-header i {
+  margin-right: 5px;
+}
+.settings-header button {
+  background: none;
+  border: none;
+  color: #fff;
+  font-size: 18px;
+  cursor: pointer;
+  line-height: 1;
+  opacity: 0.8;
+}
+.settings-header button:hover {
+  opacity: 1;
+}
+
+.settings-body {
+  padding: 10px 12px;
+}
+
+.settings-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 10px;
+}
+.settings-row label {
+  flex: 0 0 auto;
+  white-space: nowrap;
+  font-weight: 500;
+  color: #444;
+  min-width: 160px;
+}
+.settings-row select,
+.settings-row input[type="range"] {
+  flex: 1;
+}
+.settings-row select {
+  padding: 4px 8px;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  background: #fff;
+  font-size: 12px;
+}
+.settings-row input[type="range"] {
+  cursor: pointer;
+}
+.settings-row #tts-rate-value {
+  font-size: 12px;
+  font-weight: 600;
+  color: #555;
+  min-width: 24px;
+  text-align: center;
+}
+
+#popup-settings-status {
+  color: #2e7d32;
+  font-size: 12px;
+  margin: 0;
+  padding: 2px 0;
+  display: none;
+  transition: opacity 0.3s;
+}
+
+.settings-footer {
+  padding: 6px 12px 8px;
+  border-top: 1px solid #e0e0e0;
+  text-align: right;
+}
+.settings-footer a {
+  color: #BD1E2C;
+  font-size: 12px;
+  text-decoration: none;
+}
+.settings-footer a:hover {
+  text-decoration: underline;
+}


### PR DESCRIPTION
added more accessible settings menu that can be accessed on with out changing pages

Introduce an inline settings panel in the popup with a toggle button and controls for popup modifier, max results and TTS rate. Added UI (popup.html) and styles (main.css) for the panel, wired load/save logic and visual feedback in popup.js (persisting to chrome.storage.sync), and updated options defaults (options.js). content.js now reads and responds to maxResults from storage (updates MAX_RESULTS and listens for changes) and popup TTS uses the stored ttsRate. Includes UX tweaks like a close button, status message and link to full settings.