### PR TITLE
Fix/popup parsing caching

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,15 @@
+﻿# Default ignored files
+/shelf/
+/workspace.xml
+# Rider ignored files
+/contentModel.xml
+/.idea.Tureng-Chrome.iml
+/modules.xml
+/projectSettingsUpdater.xml
+# Ignored default folder with query files
+/queries/
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml
+# Editor-based HTTP Client requests
+/httpRequests/

--- a/.idea/encodings.xml
+++ b/.idea/encodings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="Encoding" addBOMForNewFiles="with BOM under Windows, with no BOM otherwise" />
+</project>

--- a/.idea/indexLayout.xml
+++ b/.idea/indexLayout.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="UserContentModel">
+    <attachedFolders />
+    <explicitIncludes />
+    <explicitExcludes />
+  </component>
+</project>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectInspectionProfilesVisibleTreeState">
+    <entry key="Project Default">
+      <profile-state>
+        <expanded-state>
+          <State>
+            <id>CSS</id>
+          </State>
+          <State>
+            <id>Docker-compose</id>
+          </State>
+          <State>
+            <id>ES2015 migration aidsJavaScript and TypeScript</id>
+          </State>
+          <State>
+            <id>GeneralJavaScript and TypeScript</id>
+          </State>
+          <State>
+            <id>HTTP Client</id>
+          </State>
+          <State>
+            <id>Imports and dependenciesJavaScript and TypeScript</id>
+          </State>
+          <State>
+            <id>Invalid elementsCSS</id>
+          </State>
+          <State>
+            <id>JavaScript and TypeScript</id>
+          </State>
+          <State>
+            <id>Less</id>
+          </State>
+          <State>
+            <id>MySQL</id>
+          </State>
+          <State>
+            <id>PostgreSQL</id>
+          </State>
+          <State>
+            <id>Protocol Buffers</id>
+          </State>
+          <State>
+            <id>RegExp</id>
+          </State>
+          <State>
+            <id>SQL</id>
+          </State>
+          <State>
+            <id>Sass/SCSS</id>
+          </State>
+          <State>
+            <id>TypeScriptJavaScript and TypeScript</id>
+          </State>
+        </expanded-state>
+        <selected-state>
+          <State>
+            <id>CSS</id>
+          </State>
+        </selected-state>
+      </profile-state>
+    </entry>
+  </component>
+</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="" vcs="Git" />
+  </component>
+</project>

--- a/Tureng/popup.html
+++ b/Tureng/popup.html
@@ -30,17 +30,17 @@
       </div>
       <div class="settings-body">
         <div class="settings-row">
-          <label for="popup-modifier-select">Popup Tetikleme Tusu:</label>
+          <label for="popup-modifier-select">Popup Tetikleme Tuşu:</label>
           <select id="popup-modifier-select">
-            <option value="alt">Alt + Cift Tiklama</option>
-            <option value="ctrl">Ctrl + Cift Tiklama</option>
-            <option value="shift">Shift + Cift Tiklama</option>
-            <option value="meta">Meta (Cmd/Win) + Cift Tiklama</option>
-            <option value="none">Sadece Cift Tiklama</option>
+            <option value="alt">Alt + Çift Tıklama</option>
+            <option value="ctrl">Ctrl + Çift Tıklama</option>
+            <option value="shift">Shift + Çift Tıklama</option>
+            <option value="meta">Meta (Cmd/Win) + Çift Tıklama</option>
+            <option value="none">Sadece Çift Tıklama</option>
           </select>
         </div>
         <div class="settings-row">
-          <label for="popup-max-results">Maks Sonuc Sayisi:</label>
+          <label for="popup-max-results">Maks. Sonuç Sayısı:</label>
           <select id="popup-max-results">
             <option value="3">3</option>
             <option value="5">5</option>
@@ -49,14 +49,14 @@
           </select>
         </div>
         <div class="settings-row">
-          <label for="popup-tts-rate">TTS Konusma Hizi:</label>
+          <label for="popup-tts-rate">TTS Konuşma Hızı:</label>
           <input type="range" id="popup-tts-rate" min="0.5" max="2.0" step="0.1" value="0.8">
           <span id="tts-rate-value">0.8</span>
         </div>
         <p id="popup-settings-status">Kaydedildi!</p>
       </div>
       <div class="settings-footer">
-        <a href="info.html" target="_blank" id="all-settings-link">Tum Ayarlar ve Bilgi <i class="fa fa-external-link" aria-hidden="true"></i></a>
+        <a href="info.html" target="_blank" id="all-settings-link">Tüm Ayarlar ve Bilgi <i class="fa fa-external-link" aria-hidden="true"></i></a>
       </div>
     </div>
 

--- a/Tureng/popup.html
+++ b/Tureng/popup.html
@@ -15,9 +15,49 @@
     <div id="form_div" class="btn-group btn-group-justified">
       <input type="search" class="form-control" id="search-input" placeholder="Türkçe veya İngilizce" autocomplete="off" autofocus tabindex="1">
       <button type="button" class="btn btn-primary" id="tureng">Tureng</button>
-     <!-- <button type="button" class="btn btn-secondary" id="settings"><i class="fa fa-sliders" aria-hidden="true"></i>  -->
+      <button type="button" id="settings-toggle" title="Ayarlar">
+        <i class="fa fa-cog fa-spin-on-hover" aria-hidden="true"></i>
+        <span>Ayarlar</span>
       </button>
     </div>
+    </div>
+
+    <!-- Inline Settings Panel -->
+    <div id="settings-panel">
+      <div class="settings-header">
+        <span><i class="fa fa-sliders" aria-hidden="true"></i> Ayarlar</span>
+        <button type="button" id="settings-close" title="Kapat">&times;</button>
+      </div>
+      <div class="settings-body">
+        <div class="settings-row">
+          <label for="popup-modifier-select">Popup Tetikleme Tusu:</label>
+          <select id="popup-modifier-select">
+            <option value="alt">Alt + Cift Tiklama</option>
+            <option value="ctrl">Ctrl + Cift Tiklama</option>
+            <option value="shift">Shift + Cift Tiklama</option>
+            <option value="meta">Meta (Cmd/Win) + Cift Tiklama</option>
+            <option value="none">Sadece Cift Tiklama</option>
+          </select>
+        </div>
+        <div class="settings-row">
+          <label for="popup-max-results">Maks Sonuc Sayisi:</label>
+          <select id="popup-max-results">
+            <option value="3">3</option>
+            <option value="5">5</option>
+            <option value="10">10</option>
+            <option value="15">15</option>
+          </select>
+        </div>
+        <div class="settings-row">
+          <label for="popup-tts-rate">TTS Konusma Hizi:</label>
+          <input type="range" id="popup-tts-rate" min="0.5" max="2.0" step="0.1" value="0.8">
+          <span id="tts-rate-value">0.8</span>
+        </div>
+        <p id="popup-settings-status">Kaydedildi!</p>
+      </div>
+      <div class="settings-footer">
+        <a href="info.html" target="_blank" id="all-settings-link">Tum Ayarlar ve Bilgi <i class="fa fa-external-link" aria-hidden="true"></i></a>
+      </div>
     </div>
 
     <div id="voice-tts" class="container">

--- a/Tureng/scripts/background.js
+++ b/Tureng/scripts/background.js
@@ -9,7 +9,7 @@ chrome.runtime.onInstalled.addListener(() => {
 chrome.contextMenus.onClicked.addListener((info) => {
   if (info.menuItemId === 'tureng_dclick_popup') {
     chrome.tabs.create({
-      url: "https://tureng.com/tr/turkce-ingilizce/" + info.selectionText.trim()
+      url: "https://tureng.com/tr/turkce-ingilizce/" + encodeURIComponent(info.selectionText.trim())
     });
   }
 });
@@ -28,7 +28,40 @@ chrome.commands.onCommand.addListener(async (command) => {
 });
 
 function stripTags(html) {
-  return html.replace(/<[^>]*>/g, '').trim();
+  return decodeHtmlEntities(html.replace(/<[^>]*>/g, '').trim());
+}
+
+function decodeHtmlEntities(text) {
+  const namedEntities = {
+    amp: '&',
+    lt: '<',
+    gt: '>',
+    quot: '"',
+    apos: "'",
+    nbsp: ' ',
+    uuml: 'ü',
+    Uuml: 'Ü',
+    ouml: 'ö',
+    Ouml: 'Ö',
+    ccedil: 'ç',
+    Ccedil: 'Ç',
+    scaron: 'ş',
+    Scaron: 'Ş',
+    igrave: 'ı',
+    Igrave: 'İ'
+  };
+
+  return text.replace(/&(#x?[0-9a-fA-F]+|[a-zA-Z]+);/g, (match, entity) => {
+    if (entity[0] === '#') {
+      const isHex = entity[1].toLowerCase() === 'x';
+      const codePoint = parseInt(entity.slice(isHex ? 2 : 1), isHex ? 16 : 10);
+      return Number.isNaN(codePoint) ? match : String.fromCodePoint(codePoint);
+    }
+
+    return Object.prototype.hasOwnProperty.call(namedEntities, entity)
+      ? namedEntities[entity]
+      : match;
+  });
 }
 
 function parseResults(htmlText) {

--- a/Tureng/scripts/background.js
+++ b/Tureng/scripts/background.js
@@ -1,25 +1,18 @@
-//Create a function to open the new tab
-function newTab(info,tab)
-{
-  const { menuItemId } = info
-
-  if (menuItemId === 'anyName'){
-    chrome.tabs.create({
-      url: "https://tureng.com/tr/turkce-ingilizce/" + info.selectionText.trim()
-    })}};
-
-//Create context menu options.
-
-chrome.contextMenus.create({
-  title: "Tureng: '%s' ",
-  id: "anyName",
-  contexts: ["selection"]
+chrome.runtime.onInstalled.addListener(() => {
+  chrome.contextMenus.create({
+    title: "Tureng: '%s' ",
+    id: "tureng_dclick_popup",
+    contexts: ["selection"]
+  });
 });
 
-
-//This tells the context menu what function to run when the option is selected
-
-chrome.contextMenus.onClicked.addListener(newTab);
+chrome.contextMenus.onClicked.addListener((info) => {
+  if (info.menuItemId === 'tureng_dclick_popup') {
+    chrome.tabs.create({
+      url: "https://tureng.com/tr/turkce-ingilizce/" + info.selectionText.trim()
+    });
+  }
+});
 
 chrome.commands.onCommand.addListener(async (command) => {
   if (command !== 'show-translation-popup') {
@@ -32,4 +25,62 @@ chrome.commands.onCommand.addListener(async (command) => {
   }
 
   chrome.tabs.sendMessage(tab.id, { type: 'TUR_ENG_SHOW_POPUP' });
+});
+
+function stripTags(html) {
+  return html.replace(/<[^>]*>/g, '').trim();
+}
+
+function parseResults(htmlText) {
+  const tableMatch = htmlText.match(/<table[^>]*class="[^"]*searchResultsTable[^"]*"[^>]*>([\s\S]*?)<\/table>/i);
+  if (!tableMatch) {
+    return [];
+  }
+  const tableHtml = tableMatch[1];
+  const rowRegex = /<tr[^>]*>([\s\S]*?)<\/tr>/gi;
+  const cellRegex = /<td[^>]*>([\s\S]*?)<\/td>/gi;
+  const results = [];
+  let rowMatch;
+
+  while ((rowMatch = rowRegex.exec(tableHtml)) !== null) {
+    const rowContent = rowMatch[1];
+    if (!/class="[^"]*rc0[^"]*"/.test(rowContent)) continue;
+
+    const cells = [];
+    let cellMatch;
+    cellRegex.lastIndex = 0;
+    while ((cellMatch = cellRegex.exec(rowContent)) !== null) {
+      cells.push(cellMatch[1]);
+    }
+    if (cells.length >= 4) {
+      const word = stripTags(cells[2]);
+      const definition = stripTags(cells[3]);
+      if (word && definition) {
+        results.push({ word, definition });
+      }
+    }
+  }
+  return results;
+}
+
+chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
+  if (message && message.type === 'TUR_ENG_FETCH') {
+    const term = message.term;
+    const maxResults = message.maxResults || 5;
+
+    fetch(`https://tureng.com/tr/turkce-ingilizce/${encodeURIComponent(term)}`)
+      .then((response) => {
+        if (!response.ok) throw new Error('Request failed');
+        return response.text();
+      })
+      .then((text) => {
+        const results = parseResults(text).slice(0, maxResults);
+        sendResponse({ success: true, results });
+      })
+      .catch(() => {
+        sendResponse({ success: false, results: [] });
+      });
+
+    return true; // keep the message channel open for async sendResponse
+  }
 });

--- a/Tureng/scripts/content.js
+++ b/Tureng/scripts/content.js
@@ -4,6 +4,7 @@
   const POPUP_ID = 'tureng-selection-popup';
   const STYLE_ID = 'tureng-selection-style';
   let MAX_RESULTS = 5;
+  let cachedPanel = null;
 
   function ensureStyles() {
     if (document.getElementById(STYLE_ID)) {
@@ -25,6 +26,7 @@
         max-width: 360px;
         font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Arial, sans-serif;
         font-size: 13px;
+        display: none;
       }
       #${POPUP_ID} .tureng-title {
         font-weight: 600;
@@ -61,25 +63,31 @@
     document.head.appendChild(style);
   }
 
-  function removePopup() {
-    const existing = document.getElementById(POPUP_ID);
-    if (existing) {
-      existing.remove();
+  function getPanel() {
+    if (cachedPanel && document.body.contains(cachedPanel)) {
+      return cachedPanel;
+    }
+    ensureStyles();
+    const panel = document.createElement('div');
+    panel.id = POPUP_ID;
+    document.body.appendChild(panel);
+    cachedPanel = panel;
+    return panel;
+  }
+
+  function hidePopup() {
+    if (cachedPanel) {
+      cachedPanel.style.display = 'none';
     }
   }
 
-  function createPopup(position) {
-    removePopup();
-    ensureStyles();
-
-    const popup = document.createElement('div');
-    popup.id = POPUP_ID;
-    popup.style.left = `${Math.max(8, position.x)}px`;
-    popup.style.top = `${Math.max(8, position.y)}px`;
-    popup.innerHTML = `<div class="tureng-loading">Loading…</div>`;
-
-    document.body.appendChild(popup);
-    return popup;
+  function showPopupAt(position) {
+    const panel = getPanel();
+    panel.style.left = `${Math.max(8, position.x)}px`;
+    panel.style.top = `${Math.max(8, position.y)}px`;
+    panel.innerHTML = `<div class="tureng-loading">Loading…</div>`;
+    panel.style.display = 'block';
+    return panel;
   }
 
   function getSelectionText() {
@@ -103,35 +111,23 @@
     };
   }
 
-  function parseResults(htmlText) {
-    const parser = new DOMParser();
-    const doc = parser.parseFromString(htmlText, 'text/html');
-    const resultsTable = doc.querySelector('.searchResultsTable');
-    if (!resultsTable) {
-      return [];
-    }
-
-    const rows = Array.from(resultsTable.querySelectorAll('tr'))
-      .filter((row) => row.querySelector('td.rc0'));
-
-    return rows.slice(0, MAX_RESULTS).map((row) => {
-      const cells = row.querySelectorAll('td');
-      const wordCell = cells[2];
-      const defCell = cells[3];
-      return {
-        word: wordCell ? wordCell.textContent.trim() : '',
-        definition: defCell ? defCell.textContent.trim() : ''
-      };
-    }).filter((row) => row.word && row.definition);
-  }
-
-  async function fetchTureng(term) {
-    const response = await fetch(`https://tureng.com/tr/turkce-ingilizce/${encodeURIComponent(term)}`);
-    if (!response.ok) {
-      throw new Error('Request failed');
-    }
-    const text = await response.text();
-    return parseResults(text);
+  function fetchTureng(term) {
+    return new Promise((resolve, reject) => {
+      chrome.runtime.sendMessage(
+        { type: 'TUR_ENG_FETCH', term, maxResults: MAX_RESULTS },
+        (response) => {
+          if (chrome.runtime.lastError) {
+            reject(new Error(chrome.runtime.lastError.message));
+            return;
+          }
+          if (response && response.success) {
+            resolve(response.results);
+          } else {
+            reject(new Error('No results'));
+          }
+        }
+      );
+    });
   }
 
   async function showPopupForSelection() {
@@ -140,7 +136,7 @@
       return;
     }
 
-    const popup = createPopup(getSelectionPosition());
+    const popup = showPopupAt(getSelectionPosition());
     popup.querySelector('.tureng-loading').textContent = `Searching "${term}"…`;
 
     try {
@@ -212,14 +208,13 @@
 
   document.addEventListener('keydown', (event) => {
     if (event.key === 'Escape') {
-      removePopup();
+      hidePopup();
     }
   });
 
   document.addEventListener('click', (event) => {
-    const popup = document.getElementById(POPUP_ID);
-    if (popup && !popup.contains(event.target)) {
-      removePopup();
+    if (cachedPanel && cachedPanel.style.display !== 'none' && !cachedPanel.contains(event.target)) {
+      hidePopup();
     }
   });
 

--- a/Tureng/scripts/content.js
+++ b/Tureng/scripts/content.js
@@ -85,9 +85,54 @@
     const panel = getPanel();
     panel.style.left = `${Math.max(8, position.x)}px`;
     panel.style.top = `${Math.max(8, position.y)}px`;
-    panel.innerHTML = `<div class="tureng-loading">Loading…</div>`;
+    const loading = document.createElement('div');
+    loading.className = 'tureng-loading';
+    loading.textContent = 'Loading…';
+    panel.replaceChildren(loading);
     panel.style.display = 'block';
     return panel;
+  }
+
+  function renderMessage(popup, className, message) {
+    const messageEl = document.createElement('div');
+    messageEl.className = className;
+    messageEl.textContent = message;
+    popup.replaceChildren(messageEl);
+  }
+
+  function renderResults(popup, term, results) {
+    const fragment = document.createDocumentFragment();
+    const title = document.createElement('div');
+    title.className = 'tureng-title';
+    title.textContent = term;
+    fragment.appendChild(title);
+
+    results.forEach((row) => {
+      const rowEl = document.createElement('div');
+      rowEl.className = 'tureng-row';
+
+      const wordEl = document.createElement('div');
+      wordEl.className = 'tureng-word';
+      wordEl.textContent = row.word;
+
+      const defEl = document.createElement('div');
+      defEl.className = 'tureng-def';
+      defEl.textContent = row.definition;
+
+      rowEl.appendChild(wordEl);
+      rowEl.appendChild(defEl);
+      fragment.appendChild(rowEl);
+    });
+
+    const link = document.createElement('a');
+    link.className = 'tureng-link';
+    link.href = `https://tureng.com/tr/turkce-ingilizce/${encodeURIComponent(term)}`;
+    link.target = '_blank';
+    link.rel = 'noopener';
+    link.textContent = 'Open in Tureng';
+    fragment.appendChild(link);
+
+    popup.replaceChildren(fragment);
   }
 
   function getSelectionText() {
@@ -142,22 +187,13 @@
     try {
       const results = await fetchTureng(term);
       if (results.length === 0) {
-        popup.innerHTML = `<div class="tureng-error">No results found.</div>`;
+        renderMessage(popup, 'tureng-error', 'No results found.');
         return;
       }
 
-      popup.innerHTML = `
-        <div class="tureng-title">${term}</div>
-        ${results.map((row) => `
-          <div class="tureng-row">
-            <div class="tureng-word">${row.word}</div>
-            <div class="tureng-def">${row.definition}</div>
-          </div>
-        `).join('')}
-        <a class="tureng-link" href="https://tureng.com/tr/turkce-ingilizce/${encodeURIComponent(term)}" target="_blank" rel="noopener">Open in Tureng</a>
-      `;
+      renderResults(popup, term, results);
     } catch (err) {
-      popup.innerHTML = `<div class="tureng-error">Failed to fetch results.</div>`;
+      renderMessage(popup, 'tureng-error', 'Failed to fetch results.');
     }
   }
 

--- a/Tureng/scripts/content.js
+++ b/Tureng/scripts/content.js
@@ -3,7 +3,7 @@
 
   const POPUP_ID = 'tureng-selection-popup';
   const STYLE_ID = 'tureng-selection-style';
-  const MAX_RESULTS = 5;
+  let MAX_RESULTS = 5;
 
   function ensureStyles() {
     if (document.getElementById(STYLE_ID)) {
@@ -166,7 +166,8 @@
   }
 
   const defaultSettings = {
-    modifier: 'alt'
+    modifier: 'alt',
+    maxResults: 5
   };
 
   let settings = { ...defaultSettings };
@@ -174,6 +175,7 @@
   function loadSettings() {
     chrome.storage.sync.get(defaultSettings, (stored) => {
       settings = { ...defaultSettings, ...stored };
+      MAX_RESULTS = settings.maxResults || 5;
     });
   }
 
@@ -233,6 +235,10 @@
     }
     if (changes.modifier) {
       settings.modifier = changes.modifier.newValue;
+    }
+    if (changes.maxResults) {
+      settings.maxResults = changes.maxResults.newValue;
+      MAX_RESULTS = settings.maxResults || 5;
     }
   });
 

--- a/Tureng/scripts/options.js
+++ b/Tureng/scripts/options.js
@@ -2,7 +2,9 @@
   'use strict';
 
   const defaultSettings = {
-    modifier: 'alt'
+    modifier: 'alt',
+    maxResults: 5,
+    ttsRate: 0.8
   };
 
   const modifierSelect = document.getElementById('modifier-select');

--- a/Tureng/scripts/popup.js
+++ b/Tureng/scripts/popup.js
@@ -168,21 +168,91 @@ window.onload = async () => {
 
 };
 
-// TTS
+// ---- Inline Settings Panel ----
+const settingsDefaults = { modifier: 'alt', maxResults: 5, ttsRate: 0.8 };
+let currentSettings = { ...settingsDefaults };
+
+function loadPopupSettings() {
+  chrome.storage.sync.get(settingsDefaults, (stored) => {
+    currentSettings = { ...settingsDefaults, ...stored };
+    applyPopupSettings();
+  });
+}
+
+function applyPopupSettings() {
+  const modSelect = document.getElementById('popup-modifier-select');
+  const maxSelect = document.getElementById('popup-max-results');
+  const rateSlider = document.getElementById('popup-tts-rate');
+  const rateLabel = document.getElementById('tts-rate-value');
+
+  if (modSelect) modSelect.value = currentSettings.modifier;
+  if (maxSelect) maxSelect.value = String(currentSettings.maxResults);
+  if (rateSlider) rateSlider.value = currentSettings.ttsRate;
+  if (rateLabel) rateLabel.textContent = currentSettings.ttsRate;
+}
+
+function savePopupSettings() {
+  const modSelect = document.getElementById('popup-modifier-select');
+  const maxSelect = document.getElementById('popup-max-results');
+  const rateSlider = document.getElementById('popup-tts-rate');
+
+  currentSettings.modifier = modSelect ? modSelect.value : settingsDefaults.modifier;
+  currentSettings.maxResults = maxSelect ? parseInt(maxSelect.value, 10) : settingsDefaults.maxResults;
+  currentSettings.ttsRate = rateSlider ? parseFloat(rateSlider.value) : settingsDefaults.ttsRate;
+
+  chrome.storage.sync.set(currentSettings, () => {
+    const status = document.getElementById('popup-settings-status');
+    if (status) {
+      status.style.display = 'block';
+      clearTimeout(savePopupSettings._timer);
+      savePopupSettings._timer = setTimeout(() => {
+        status.style.display = 'none';
+      }, 1200);
+    }
+  });
+}
+
+// Toggle panel open/close
+document.getElementById('settings-toggle').addEventListener('click', () => {
+  const panel = document.getElementById('settings-panel');
+  const btn = document.getElementById('settings-toggle');
+  panel.classList.toggle('open');
+  btn.classList.toggle('panel-open');
+});
+document.getElementById('settings-close').addEventListener('click', () => {
+  document.getElementById('settings-panel').classList.remove('open');
+  document.getElementById('settings-toggle').classList.remove('panel-open');
+});
+
+// Wire setting controls
+document.getElementById('popup-modifier-select').addEventListener('change', savePopupSettings);
+document.getElementById('popup-max-results').addEventListener('change', savePopupSettings);
+document.getElementById('popup-tts-rate').addEventListener('input', () => {
+  document.getElementById('tts-rate-value').textContent = document.getElementById('popup-tts-rate').value;
+});
+document.getElementById('popup-tts-rate').addEventListener('change', savePopupSettings);
+
+loadPopupSettings();
+
+// TTS (uses stored rate)
+function getTtsRate() {
+  return currentSettings.ttsRate || 0.8;
+}
+
 document.getElementById('flag-tr').addEventListener('click', ()=>{
-  chrome.tts.speak(document.getElementById('search-input').value, {'lang': 'tr-TR', 'rate': 0.8});
+  chrome.tts.speak(document.getElementById('search-input').value, {'lang': 'tr-TR', 'rate': getTtsRate()});
 });
 
 document.getElementById('flag-us').addEventListener('click', ()=>{
-  chrome.tts.speak(document.getElementById('search-input').value, {'lang': 'en-US', 'rate': 0.8});
+  chrome.tts.speak(document.getElementById('search-input').value, {'lang': 'en-US', 'rate': getTtsRate()});
 });
 
 document.getElementById('flag-uk').addEventListener('click', ()=>{
-  chrome.tts.speak(document.getElementById('search-input').value, {'lang': 'en-GB', 'rate': 0.8});
+  chrome.tts.speak(document.getElementById('search-input').value, {'lang': 'en-GB', 'rate': getTtsRate()});
 });
 
 document.getElementById('flag-au').addEventListener('click', ()=>{
-  chrome.tts.speak(document.getElementById('search-input').value, {'lang': 'en-AU', 'rate': 0.8});
+  chrome.tts.speak(document.getElementById('search-input').value, {'lang': 'en-AU', 'rate': getTtsRate()});
 });
 
 // tureng-logo

--- a/Tureng/styles/main.css
+++ b/Tureng/styles/main.css
@@ -86,3 +86,162 @@ table tbody a:hover {
 .search_results {
   width: 450px;
 }
+
+/* ---- Settings Toggle Button ---- */
+#settings-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  background: linear-gradient(135deg, #BD1E2C, #e0313f);
+  border: none;
+  color: #fff;
+  font-size: 13px;
+  font-weight: 600;
+  padding: 7px 14px;
+  margin-left: 6px;
+  border-radius: 6px;
+  cursor: pointer;
+  transition: background 0.25s, box-shadow 0.25s, transform 0.15s;
+  outline: none;
+  box-shadow: 0 2px 6px rgba(189, 30, 44, 0.35);
+  animation: settingsPulse 2s ease-in-out 0.5s 3;
+}
+#settings-toggle i {
+  font-size: 15px;
+  transition: transform 0.4s ease;
+}
+#settings-toggle:hover {
+  background: linear-gradient(135deg, #a01825, #c9252f);
+  box-shadow: 0 3px 10px rgba(189, 30, 44, 0.5);
+  transform: translateY(-1px);
+}
+#settings-toggle:hover i {
+  transform: rotate(90deg);
+}
+#settings-toggle:active {
+  transform: translateY(0);
+  box-shadow: 0 1px 4px rgba(189, 30, 44, 0.3);
+}
+#settings-toggle.panel-open {
+  background: linear-gradient(135deg, #8a1420, #a01825);
+}
+
+@keyframes settingsPulse {
+  0%, 100% { box-shadow: 0 2px 6px rgba(189, 30, 44, 0.35); }
+  50% { box-shadow: 0 2px 14px rgba(189, 30, 44, 0.6); }
+}
+
+/* ---- Settings Panel ---- */
+#settings-panel {
+  display: none;
+  background: #fafafa;
+  border: 1px solid #e0e0e0;
+  border-radius: 6px;
+  margin: 0 6px 8px 6px;
+  font-size: 13px;
+  overflow: hidden;
+  animation: settingsSlideDown 0.2s ease-out;
+}
+
+@keyframes settingsSlideDown {
+  from {
+    opacity: 0;
+    max-height: 0;
+  }
+  to {
+    opacity: 1;
+    max-height: 400px;
+  }
+}
+
+#settings-panel.open {
+  display: block;
+}
+
+.settings-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 8px 12px;
+  background: #BD1E2C;
+  color: #fff;
+  font-weight: 600;
+  font-size: 13px;
+}
+.settings-header i {
+  margin-right: 5px;
+}
+.settings-header button {
+  background: none;
+  border: none;
+  color: #fff;
+  font-size: 18px;
+  cursor: pointer;
+  line-height: 1;
+  opacity: 0.8;
+}
+.settings-header button:hover {
+  opacity: 1;
+}
+
+.settings-body {
+  padding: 10px 12px;
+}
+
+.settings-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 10px;
+}
+.settings-row label {
+  flex: 0 0 auto;
+  white-space: nowrap;
+  font-weight: 500;
+  color: #444;
+  min-width: 160px;
+}
+.settings-row select,
+.settings-row input[type="range"] {
+  flex: 1;
+}
+.settings-row select {
+  padding: 4px 8px;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  background: #fff;
+  font-size: 12px;
+}
+.settings-row input[type="range"] {
+  cursor: pointer;
+}
+.settings-row #tts-rate-value {
+  font-size: 12px;
+  font-weight: 600;
+  color: #555;
+  min-width: 24px;
+  text-align: center;
+}
+
+#popup-settings-status {
+  color: #2e7d32;
+  font-size: 12px;
+  margin: 0;
+  padding: 2px 0;
+  display: none;
+  transition: opacity 0.3s;
+}
+
+.settings-footer {
+  padding: 6px 12px 8px;
+  border-top: 1px solid #e0e0e0;
+  text-align: right;
+}
+.settings-footer a {
+  color: #BD1E2C;
+  font-size: 12px;
+  text-decoration: none;
+}
+.settings-footer a:hover {
+  text-decoration: underline;
+}


### PR DESCRIPTION
refactor: move Tureng fetch from content script to background service worker to avoid CORS dependency on host page origin
fix: resolve "Failed to fetch results" by using regex HTML parser in service worker (no DOMParser in MV3 workers), fix duplicate context menu error by creating menu items in onInstalled listener
feat: cache popup panel DOM element for reuse instead of recreating on every double-click